### PR TITLE
Fixed Evaluation Denoising Sigma Error

### DIFF
--- a/data/dataset_video_test.py
+++ b/data/dataset_video_test.py
@@ -211,6 +211,7 @@ class SingleVideoRecurrentTestDataset(data.Dataset):
 
         # Find unique folder strings
         self.folders = sorted(list(set(self.data_info['folder'])))
+        self.sigma = opt['sigma'] / 255. if 'sigma' in opt else 0 # for non-blind video denoising
 
     def __getitem__(self, index):
         folder = self.folders[index]
@@ -219,6 +220,13 @@ class SingleVideoRecurrentTestDataset(data.Dataset):
             imgs_lq = self.imgs_lq[folder]
         else:
             imgs_lq = utils_video.read_img_seq(self.imgs_lq[folder])
+
+        if self.sigma:
+        # for non-blind video denoising
+            torch.manual_seed(0)
+            noise_level = torch.ones((1, 1, 1, 1)) * self.sigma
+            t, _, h, w = imgs_lq.shape
+            imgs_lq = torch.cat([imgs_lq, noise_level.expand(t, 1, h, w)], 1)
 
         return {
             'L': imgs_lq,


### PR DESCRIPTION
Fixes #24

Fixes the channel error by adding the non-blind channel in the evaluation dataloader, note this still requires the user to input a sigma which will then be used as the denoising strength for the evaluation model.